### PR TITLE
Changes to support partition key in range sensitivity experiments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,5 +88,13 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>cassandra-it</id>
+			<properties>
+				<skipITs>false</skipITs>
+				<guava.version>19.0</guava.version>
+				<testStoreType>CASSANDRA</testStoreType>
+			</properties>
+	    </profile>
 	</profiles>
 </project>

--- a/src/main/java/mil/nga/giat/geowave/experiment/ExperimentMain.java
+++ b/src/main/java/mil/nga/giat/geowave/experiment/ExperimentMain.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.ArrayUtils;
 
 public class ExperimentMain
 {
-	public static long TOTAL = 1000000L;
+	public static long TOTAL = 1000L;
 	public static int SAMPLE_SIZE = 10;
 
 	// there's probably a cap on the ranges before it just takes ridiculously
@@ -16,40 +16,45 @@ public class ExperimentMain
 	// decomposition we end up with 10's of thousands of ranges, now that could
 	// be multiplied by the number of hashes/partitions, but there still is some
 	// logical cap on the number of ranges that we'll ever realistically use)
-	public static long MAX_RANGES = 1000000L;
+	public static long MAX_RANGES = 10000L;
 
+	//Number of partition keys
+	public static int NO_PARTITION_KEYS = 5;
+	
 	public static void main(
 			final String[] args )
 			throws Exception {
 		TOTAL = Long.parseLong(args[1]);
 		MAX_RANGES = Long.parseLong(args[2]);
 		SAMPLE_SIZE = Integer.parseInt(args[3]);
+		NO_PARTITION_KEYS = Integer.parseInt(args[4]);
 		switch (args[0]) {
 			case "hbase":
 				HBaseRangeSensitivity.main(ArrayUtils.subarray(
 						args,
-						4,
+						5,
 						args.length));
 				break;
 			case "accumulo":
 				AccumuloRangeSensitivity.main(ArrayUtils.subarray(
 						args,
-						4,
+						5,
 						args.length));
 				break;
 			case "dynamodb":
 				DynamoDBRangeSensitivity.main(ArrayUtils.subarray(
 						args,
-						4,
+						5,
 						args.length));
 				break;
 
 			case "cassandra":
 				CassandraRangeSensitivity.main(ArrayUtils.subarray(
 						args,
-						4,
+						5,
 						args.length));
 				break;
 		}
 	}
+	
 }

--- a/src/main/java/mil/nga/giat/geowave/experiment/Statistics.java
+++ b/src/main/java/mil/nga/giat/geowave/experiment/Statistics.java
@@ -18,6 +18,7 @@ public class Statistics
 
 	double[] data;
 	int size;
+	int noPartitionKeys;
 	private final long rangeCount;
 	private final long entryCount;
 	private static PrintWriter writer = null;
@@ -25,14 +26,21 @@ public class Statistics
 	private static final SimpleDateFormat sdf = new SimpleDateFormat(
 			"yyyy-MM-dd_HH-mm-ss");
 
+	public Statistics(final double[] data,
+			final long rangeCount,
+			final long entryCount, 
+			int paritionKeys){
+		this.data = data;
+		this.rangeCount = rangeCount;
+		this.entryCount = entryCount;
+		noPartitionKeys = paritionKeys;
+		size = data.length;
+	}
 	public Statistics(
 			final double[] data,
 			final long rangeCount,
 			final long entryCount ) {
-		this.data = data;
-		this.rangeCount = rangeCount;
-		this.entryCount = entryCount;
-		size = data.length;
+		this(data,rangeCount,entryCount,1);
 	}
 
 	public static void initializeFile(
@@ -87,14 +95,15 @@ public class Statistics
 	}
 
 	public static String getCSVHeader() {
-		return "Range Count, Result Count, Mean (ms), Median (ms), Std Dev (ms)";
+		return "Range Count, Result Count, Parition Keys, Mean (ms), Median (ms), Std Dev (ms)";
 	}
 
 	public String toCSVRow() {
 		return String.format(
-				"%s,%s,%s,%s,%s",
+				"%s,%s,%s,%s,%s,%s",
 				rangeCount,
 				entryCount,
+				noPartitionKeys,
 				getMean(),
 				median(),
 				getStdDev());


### PR DESCRIPTION
Added support for partition keys in Cassandra and DynamoDB. There is now an additional option in ExperimentMain which indicates the number of partition keys.

Each experiment is repeated for every partition key and the output file now has a new column called Partition key. 

If the number of range requests are 1000 and partition key is 5, that indicates that we would together do 5*1000 = 5000 range requests.
